### PR TITLE
Fix issue: query->wheres can be empty

### DIFF
--- a/src/GlobeCode/LaravelMultiTenant/TenantScope.php
+++ b/src/GlobeCode/LaravelMultiTenant/TenantScope.php
@@ -40,7 +40,7 @@ class TenantScope implements ScopeInterface {
     {
         if (self::getOverride() === false)
         {
-            $tenantId = (int) trim(self::getTenantId());
+            $tenantId = trim(self::getTenantId());
 
             if (is_null($tenantId) || empty($tenantId) || $tenantId < 1)
                 throw new TenantIdNotSetException;

--- a/src/GlobeCode/LaravelMultiTenant/TenantScope.php
+++ b/src/GlobeCode/LaravelMultiTenant/TenantScope.php
@@ -90,7 +90,7 @@ class TenantScope implements ScopeInterface {
         $query->setBindings(array_values($bindings['where']));
 
         // Repopulate the query 'wheres' only.
-        $query->wheres = array_values($query->wheres);
+        $query->wheres = is_array($query->wheres) ? array_values($query->wheres) : null;
     }
 
     /**


### PR DESCRIPTION
Hi, 
I've update the TenantScope to avoid errors when no where clause is used in the original builder
